### PR TITLE
Add error helper and replace unwrap in normalized_mount_point

### DIFF
--- a/bbfs-cli/src/main.rs
+++ b/bbfs-cli/src/main.rs
@@ -30,9 +30,16 @@ struct BbfsCli {
     mount_point: PathBuf,
 }
 
+fn exit_error<E: std::fmt::Display>(e: E) -> ! {
+    eprintln!("Error: {e}");
+    std::process::exit(1);
+}
+
 impl BbfsCli {
     fn normalized_mount_point(&self) -> PathBuf {
-        self.mount_point.canonicalize().unwrap()
+        self.mount_point
+            .canonicalize()
+            .unwrap_or_else(|e| exit_error(e))
     }
 }
 


### PR DESCRIPTION
- Added exit_error, which prints an error message and exits with status code 1.
- Updated normalized_mount_point to use .unwrap_or_else(exit_error) instead of .unwrap(), preventing panics when canonicalize() fails